### PR TITLE
Add quality of life fixes

### DIFF
--- a/Shotty Bird Shared/Ads Manager/AdsManager.swift
+++ b/Shotty Bird Shared/Ads Manager/AdsManager.swift
@@ -51,9 +51,6 @@ final class AdsManager: NSObject {
         Task {
             if await !StoreManager.shared.unlockRemoveAds() && !isInitialized {
                 await GADMobileAds.sharedInstance().start()
-                #if DEBUG
-                    GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = ["a960bf9981e0d32eacbefcf6351bc84c"]
-                #endif
                 loadAds()
                 isInitialized = true
             }

--- a/Shotty Bird Shared/Scenes/DifficultyScene.swift
+++ b/Shotty Bird Shared/Scenes/DifficultyScene.swift
@@ -169,14 +169,6 @@ class DifficultyScene: BaseScene {
     /// Handles the easy button tap event.
     /// - Parameter location: A point where the screen is tapped.
     private func handleEasyButton(in location: CGPoint) {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-              let rootViewController = appDelegate.window?.rootViewController as? GameViewController else {
-            return
-        }
-        if !rootViewController.loadingOverlay.isHidden {
-            return
-        }
-        
         guard let easyButton = childNode(withName: "easyButton") else {
             return
         }
@@ -195,14 +187,6 @@ class DifficultyScene: BaseScene {
     /// Handles the normal button tap event.
     /// - Parameter location: A point where the screen is tapped.
     private func handleNormalButton(in location: CGPoint) {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-              let rootViewController = appDelegate.window?.rootViewController as? GameViewController else {
-            return
-        }
-        if !rootViewController.loadingOverlay.isHidden {
-            return
-        }
-        
         guard let normalButton = childNode(withName: "normalButton") else {
             return
         }
@@ -221,14 +205,6 @@ class DifficultyScene: BaseScene {
     /// Handles the hard button tap event.
     /// - Parameter location: A point where the screen is tapped.
     private func handleHardButton(in location: CGPoint) {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-              let rootViewController = appDelegate.window?.rootViewController as? GameViewController else {
-            return
-        }
-        if !rootViewController.loadingOverlay.isHidden {
-            return
-        }
-        
         guard let hardButton = childNode(withName: "hardButton") else {
             return
         }
@@ -298,6 +274,8 @@ extension DifficultyScene {
 
 extension DifficultyScene: AdsManagerDelegate {
     func adDidDismiss(withReward: Bool) {
-        launchPractice()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.launchPractice()
+        }
     }
 }

--- a/Shotty Bird Shared/Scenes/GameModeScene.swift
+++ b/Shotty Bird Shared/Scenes/GameModeScene.swift
@@ -203,14 +203,6 @@ class GameModeScene: BaseScene {
     /// Handles the practice button tap event.
     /// - Parameter location: A point where the screen is tapped.
     private func handlePracticeButton(in location: CGPoint) {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-              let rootViewController = appDelegate.window?.rootViewController as? GameViewController else {
-            return
-        }
-        if !rootViewController.loadingOverlay.isHidden {
-            return
-        }
-        
         guard let practiceButton = childNode(withName: "practiceButton") else {
             return
         }
@@ -291,7 +283,9 @@ extension GameModeScene {
 
 extension GameModeScene: AdsManagerDelegate {
     func adDidDismiss(withReward: Bool) {
-        launchGame(mode: selectedMode, withReward: withReward)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.launchGame(mode: self.selectedMode, withReward: withReward)
+        }
     }
 }
 

--- a/Shotty Bird Shared/Scenes/MainMenuScene.swift
+++ b/Shotty Bird Shared/Scenes/MainMenuScene.swift
@@ -179,9 +179,7 @@ class MainMenuScene: BaseScene {
             if !audioManager.isMuted {
                 run(playExplosionSoundAction)
             }
-            if gameCenterButton.contains(location) && GameCenterHelper.shared.isGameCenterEnabled {
-                GameCenterHelper.shared.presentGameCenterViewController()
-            }
+            GameCenterHelper.shared.presentGameCenterViewController()
         }
     }
     
@@ -275,6 +273,13 @@ class MainMenuScene: BaseScene {
 
 extension MainMenuScene {
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+              let rootViewController = appDelegate.window?.rootViewController as? GameViewController else {
+            return
+        }
+        if !rootViewController.loadingOverlay.isHidden {
+            return
+        }
         for touch in touches {
             let location = touch.location(in: self)
             // Handle play button tap


### PR DESCRIPTION
- Transitions to game scene are done on main thread after an ad is dismissed
- Pausing the game while playing Time Attack will correctly pause/resume timer
- Prevent main menu scene buttons from being tapped behind the loading overlay while ads are being loaded
- Present Game Center view controller even if player hasn't previously authenticated with the service